### PR TITLE
Use octal notation instead of symbolic notation

### DIFF
--- a/automated_root/utils/mtksu.py
+++ b/automated_root/utils/mtksu.py
@@ -40,10 +40,10 @@ def cmd_handler(client, opt):
 
     logger.log("Send files")
     for file in os.listdir('automated_root/files/common'):
-        dev.push(f'automated_root/files/common/{file}', f'/data/local/tmp/{file}', perms='a+x')
+        dev.push(f'automated_root/files/common/{file}', f'/data/local/tmp/{file}', perms='775')
 
     for file in os.listdir(f'automated_root/files/{dev.arch}'):
-        dev.push(f'automated_root/files/{dev.arch}/{file}', f'/data/local/tmp/{dev.arch}/{file}', perms='a+x')
+        dev.push(f'automated_root/files/{dev.arch}/{file}', f'/data/local/tmp/{dev.arch}/{file}', perms='775')
 
     with Switch(opt) as s:
         if s.case(1):


### PR DESCRIPTION
Some versions of `chmod` don't understand symbolic notation (e.g. `a+x`), but they do all understand octal notation.

Trying this first-hand on my Kindle Fire HD 8 makes the script fail due to usage of symbolic notation. When switched to octal notation, the script continues